### PR TITLE
Add payroll extraction script

### DIFF
--- a/extract_nomina.py
+++ b/extract_nomina.py
@@ -12,18 +12,28 @@ from typing import List, Optional
 import pandas as pd
 import pdfplumber
 
-logging.basicConfig(level=logging.INFO)
+logging.basicConfig(level=logging.INFO, format="%(levelname)s:%(message)s")
 
 NUMBER_RE = re.compile(r"[\d\.]*,\d{2}")
 
 
 def parse_number(value: str) -> Optional[float]:
-    """Convert a Spanish-formatted number to float.
+    """Convert a Spanish-formatted number to ``float``.
 
-    Dashes or empty values return ``None``.
+    Parameters
+    ----------
+    value:
+        String containing the number, e.g. ``"2.173,52"``.
+
+    Returns
+    -------
+    Optional[float]
+        The parsed float or ``None`` if the value is empty or invalid.
     """
     value = value.strip()
     if not value or value in {"—", "-"}:
+        return None
+    if not NUMBER_RE.fullmatch(value):
         return None
     value = value.replace(".", "").replace(",", ".")
     try:

--- a/extract_nomina.py
+++ b/extract_nomina.py
@@ -1,0 +1,121 @@
+"""Extract payroll data from Mercedes-Benz Vitoria PDF payrolls."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import re
+from pathlib import Path
+from typing import List, Optional
+
+import pandas as pd
+import pdfplumber
+
+logging.basicConfig(level=logging.INFO)
+
+NUMBER_RE = re.compile(r"[\d\.]*,\d{2}")
+
+
+def parse_number(value: str) -> Optional[float]:
+    """Convert a Spanish-formatted number to float.
+
+    Dashes or empty values return ``None``.
+    """
+    value = value.strip()
+    if not value or value in {"—", "-"}:
+        return None
+    value = value.replace(".", "").replace(",", ".")
+    try:
+        return float(value)
+    except ValueError:
+        return None
+
+
+LINE_RE = re.compile(
+    r"^(?P<code>\d+)\s+"  # line code
+    r"(?P<concept>.+?)\s+"  # concept description
+    r"(?P<units>[\d\.]*,\d{2}|—|-)\s+"  # units
+    r"(?P<base>[\d\.]*,\d{2}|—|-)\s+"  # base
+    r"(?P<devengo>[\d\.]*,\d{2}|—|-)\s+"  # devengo
+    r"(?P<deduccion>[\d\.]*,\d{2}|—|-)"  # deduccion
+)
+
+
+def parse_nomina(path_pdf: Path) -> pd.DataFrame:
+    """Parse Mercedes-Benz payroll PDF into a DataFrame.
+
+    Parameters
+    ----------
+    path_pdf:
+        Path to the PDF file.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Extracted payroll concepts.
+    """
+    records: List[dict[str, Optional[float] | str]] = []
+    with pdfplumber.open(str(path_pdf)) as pdf:
+        for page in pdf.pages:
+            text = page.extract_text() or ""
+            for line in text.splitlines():
+                line = line.strip()
+                match = LINE_RE.match(line)
+                if match:
+                    gd = match.groupdict()
+                    records.append(
+                        {
+                            "concepto": gd["concept"].strip(),
+                            "unidades": parse_number(gd["units"]),
+                            "base": parse_number(gd["base"]),
+                            "devengo": parse_number(gd["devengo"]),
+                            "deduccion": parse_number(gd["deduccion"]),
+                        }
+                    )
+    return pd.DataFrame(
+        records,
+        columns=["concepto", "unidades", "base", "devengo", "deduccion"],
+    )
+
+
+def detect_downloads() -> Path:
+    """Return the user's Downloads folder, ensuring it exists."""
+    if os.name == "nt":
+        base = Path(os.environ.get("USERPROFILE", Path.home()))
+    else:
+        base = Path.home()
+    downloads = base / "Downloads"
+    downloads.mkdir(parents=True, exist_ok=True)
+    return downloads
+
+
+def save_to_csv(df: pd.DataFrame, output: Path) -> None:
+    """Save the DataFrame to CSV."""
+    df.to_csv(output, index=False)
+    logging.info("Saved CSV to %s", output)
+
+
+def main() -> None:
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(description="Extract payroll PDF to CSV")
+    parser.add_argument("pdf", type=Path, help="Path to PDF file")
+    parser.add_argument("-o", "--output", type=Path, help="CSV output path")
+    parser.add_argument(
+        "-d", "--to-downloads", action="store_true", help="Save CSV to Downloads"
+    )
+    args = parser.parse_args()
+
+    df = parse_nomina(args.pdf)
+
+    if args.to_downloads:
+        output = detect_downloads() / f"{args.pdf.stem}.csv"
+        save_to_csv(df, output)
+    elif args.output:
+        save_to_csv(df, args.output)
+    else:
+        print(df)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_extract_nomina.py
+++ b/tests/test_extract_nomina.py
@@ -66,6 +66,10 @@ def test_number_conversion_handles_comma_decimal():
     assert en.parse_number('2.173,52') == 2173.52
 
 
+def test_parse_number_returns_none_for_invalid():
+    assert en.parse_number('invalid') is None
+
+
 def test_downloads_path_exists(monkeypatch):
     monkeypatch.delenv('USERPROFILE', raising=False)
     path = en.detect_downloads()

--- a/tests/test_extract_nomina.py
+++ b/tests/test_extract_nomina.py
@@ -1,0 +1,72 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import types
+from pathlib import Path
+
+# Dummy pandas module
+pandas = types.ModuleType('pandas')
+
+class DummyDataFrame(list):
+    def __init__(self, data=None, columns=None):
+        super().__init__(data or [])
+        self.columns = columns
+        self.empty = not bool(data)
+
+    def to_csv(self, *args, **kwargs):
+        pass
+
+pandas.DataFrame = DummyDataFrame
+sys.modules['pandas'] = pandas
+
+# Dummy pdfplumber module
+pdfplumber = types.ModuleType('pdfplumber')
+
+class DummyPage:
+    def __init__(self, text: str):
+        self._text = text
+
+    def extract_text(self):
+        return self._text
+
+class DummyPDF:
+    def __init__(self, pages):
+        self.pages = pages
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        pass
+
+def dummy_open(path):
+    text = "001 Salario base        30,00 2.228,35 2.228,35 0,00"
+    return DummyPDF([DummyPage(text)])
+
+pdfplumber.open = dummy_open
+sys.modules['pdfplumber'] = pdfplumber
+
+import extract_nomina as en
+
+
+def test_parse_nomina_returns_dataframe(monkeypatch):
+    df = en.parse_nomina(Path('dummy.pdf'))
+    assert isinstance(df, pandas.DataFrame)
+    assert not df.empty
+    assert df.columns == [
+        'concepto',
+        'unidades',
+        'base',
+        'devengo',
+        'deduccion',
+    ]
+
+
+def test_number_conversion_handles_comma_decimal():
+    assert en.parse_number('2.173,52') == 2173.52
+
+
+def test_downloads_path_exists(monkeypatch):
+    monkeypatch.delenv('USERPROFILE', raising=False)
+    path = en.detect_downloads()
+    assert path.exists()


### PR DESCRIPTION
## Summary
- implement `extract_nomina.py` script for payroll PDF parsing
- provide CLI options for CSV export and downloads folder detection
- add unit tests for core logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e72656344832ba90dc4d70f8bd756